### PR TITLE
Use paho-mqtt reconnect feature instead of explicit call

### DIFF
--- a/src/MqttObserver.py
+++ b/src/MqttObserver.py
@@ -21,6 +21,7 @@ class MqttObserver:
         self.topics = topics
 
         self.client = mqtt.Client()
+        self.client.reconnect_on_failure = True
         self.client.on_connect = self.on_connect
         self.client.on_disconnect = self.on_disconnect
         self.client.on_message = self.on_message
@@ -35,11 +36,10 @@ class MqttObserver:
             print(f"Subscribing to topic {key}")
             client.subscribe(self.topics[key])
 
-    def on_disconnect(self, client, userdata, rc):
+    @staticmethod
+    def on_disconnect(_client, _userdata, rc):
         print(f"Disconnected with result code {rc}")
-        if rc != 0:
-            print("Unexpected disconnection. Reconnecting...")
-            self.client.reconnect()
+        # Reconnect is done automatically by the client due to reconnect_on_failure=True
 
     def on_message(self, client, userdata, msg):
         print(f"Message received on topic {msg.topic}: {msg.payload.decode()}")


### PR DESCRIPTION
This pull request introduces changes to the `MqttObserver` class to improve the handling of MQTT client disconnections and simplify the code. The most important updates include enabling automatic reconnection and refactoring the `on_disconnect` method to remove redundant logic.

Fixes #7 

### Improvements to MQTT client reconnection:

* [`src/MqttObserver.py`](diffhunk://#diff-0dc1a9f5b91383c628b93a71ce4170d69e3232a645393a4b7dffa8ec924f18f7R24): Enabled automatic reconnection by setting `self.client.reconnect_on_failure = True` in the `__init__` method. This eliminates the need for manual reconnection logic.

### Code simplification:

* [`src/MqttObserver.py`](diffhunk://#diff-0dc1a9f5b91383c628b93a71ce4170d69e3232a645393a4b7dffa8ec924f18f7L38-R42): Refactored the `on_disconnect` method to be a `@staticmethod` and removed the manual reconnection logic, as the client now handles reconnections automatically.